### PR TITLE
Fix usage example in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ $ react-native link react-native-url-resolver
 
 # Usage
 ```
-import urlResolver from 'react-native-url-resolver';
-const url = await urlResolver.resolve('http://link.your-website.com/wf/click?upn=2BpJel-2FskgqgVk-2FpxfUI2LQoBBIQ');
+import { resolveUrl } from 'react-native-url-resolver';
+const url = await resolveUrl('http://link.your-website.com/wf/click?upn=2BpJel-2FskgqgVk-2FpxfUI2LQoBBIQ');
 ```


### PR DESCRIPTION
Hi. I think the code showed in README doesn't work as it is, as `resolveUrl`, instead of `urlResolver`, is exported in `index.js`. Moreover, as there's no default export there, I believe curly brackets are needed.