### PR TITLE
Use the original URL when no redirection is involved.

### DIFF
--- a/android/src/main/java/com/urlresolver/RNUrlResolverModule.java
+++ b/android/src/main/java/com/urlresolver/RNUrlResolverModule.java
@@ -34,8 +34,12 @@ public class RNUrlResolverModule extends ReactContextBaseJavaModule {
                     URL originalURL = new URL(url);
                     HttpURLConnection ucon = (HttpURLConnection) originalURL.openConnection();
                     ucon.setInstanceFollowRedirects(false);
-                    URL resolvedURL = new URL(ucon.getHeaderField("Location"));
-                    promise.resolve(resolvedURL.toString());
+                    String location = ucon.getHeaderField("Location");
+                    if (location == null) promise.resolve(originalURL.toString());
+                    else {
+                        URL resolvedURL = new URL(location);
+                        promise.resolve(resolvedURL.toString());
+                    }
                 }
                 catch (MalformedURLException ex) {
                     Log.e("App Link",Log.getStackTraceString(ex));


### PR DESCRIPTION
A user might invokes this library without knowing a URL will be redirected or can be used as it is. However, with the current implementation for Android, when the URL doesn't redirect to anywhere, it throws `MalformedURLException`.

```
02-15 18:56:15.091  9513 10048 E ReactNativeJS: { [Error: java.net.MalformedURLException: Attempt to invoke virtual method 'int java.lang.String.length()' on a null object reference
02-15 18:56:15.091  9513 10048 E ReactNativeJS:         at java.net.URL.<init>(URL.java:623)
02-15 18:56:15.091  9513 10048 E ReactNativeJS:         at java.net.URL.<init>(URL.java:486)
02-15 18:56:15.091  9513 10048 E ReactNativeJS:         at java.net.URL.<init>(URL.java:435)
02-15 18:56:15.091  9513 10048 E ReactNativeJS:         at com.urlresolver.RNUrlResolverModule$1.run(RNUrlResolverModule.java:37)
02-15 18:56:15.091  9513 10048 E ReactNativeJS:         at java.lang.Thread.run(Thread.java:776)
02-15 18:56:15.091  9513 10048 E ReactNativeJS: Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.String.length()' on a null object reference
02-15 18:56:15.091  9513 10048 E ReactNativeJS:         at java.net.URL.<init>(URL.java:528)
02-15 18:56:15.091  9513 10048 E ReactNativeJS:         ... 4 more
02-15 18:56:15.091  9513 10048 E ReactNativeJS: ]
```

I suppose it's more convenient for a user to be able to pass a URL of both cases, with and without redirection.