### PR TITLE
Updating iOS native module to properly pull Location header from http response

### DIFF
--- a/ios/RNUrlResolver.h
+++ b/ios/RNUrlResolver.h
@@ -1,5 +1,5 @@
 #import <React/RCTBridgeModule.h>
 
-@interface RNUrlResolver : NSObject <RCTBridgeModule>
+@interface RNUrlResolver : NSObject <RCTBridgeModule, NSURLSessionDelegate>
 
 @end

--- a/ios/RNUrlResolver.m
+++ b/ios/RNUrlResolver.m
@@ -15,19 +15,29 @@ RCT_EXPORT_METHOD(resolveUrl:(NSURL *)encodedURL
     if (encodedURL == nil) {
         reject(0, @"Unable to handle user activity: No URL provided", nil);
     } else {
-        NSURLSession *session = [NSURLSession sharedSession];
+      NSURLSessionConfiguration *configuration = NSURLSessionConfiguration.defaultSessionConfiguration;
+        NSURLSession *session = [NSURLSession sessionWithConfiguration:configuration delegate:self delegateQueue:[NSOperationQueue mainQueue]];
         NSURLSessionDataTask *task = [session dataTaskWithURL:encodedURL completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
-            if (response == nil || [response URL] == nil) {
-                // RCTLogError(@"Unable to handle URL: %@", encodedURL.absoluteString);
+            if (response == nil || ![response isKindOfClass:[NSHTTPURLResponse class]]) {
                 reject(0, @"Unable to handle URL", nil);
             } else {
-                NSURL *resolvedURL = [response URL];
-                resolve(resolvedURL.absoluteString);
+                NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*)response;
+                NSString *urlAsString = [httpResponse valueForHTTPHeaderField:@"Location"];
+                if ([urlAsString length] == 0) {
+                  resolve([httpResponse URL].absoluteString);
+                } else {
+                  resolve(urlAsString);
+                }
             }
         }];
         [task resume];
         
     }
+}
+
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task willPerformHTTPRedirection:(NSHTTPURLResponse *)response newRequest:(NSURLRequest *)request completionHandler:(void (^)(NSURLRequest * _Nullable))completionHandler {
+    // Stops the redirection, and returns (internally) the response body.
+    completionHandler(nil);
 }
 
 @end

--- a/ios/RNUrlResolver.m
+++ b/ios/RNUrlResolver.m
@@ -15,7 +15,7 @@ RCT_EXPORT_METHOD(resolveUrl:(NSURL *)encodedURL
     if (encodedURL == nil) {
         reject(0, @"Unable to handle user activity: No URL provided", nil);
     } else {
-      NSURLSessionConfiguration *configuration = NSURLSessionConfiguration.defaultSessionConfiguration;
+        NSURLSessionConfiguration *configuration = NSURLSessionConfiguration.defaultSessionConfiguration;
         NSURLSession *session = [NSURLSession sessionWithConfiguration:configuration delegate:self delegateQueue:[NSOperationQueue mainQueue]];
         NSURLSessionDataTask *task = [session dataTaskWithURL:encodedURL completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
             if (response == nil || ![response isKindOfClass:[NSHTTPURLResponse class]]) {


### PR DESCRIPTION
* Current code only pulls the followed redirect URL, which is incorrect
* the Location header returned by SendGrid is the actual URL we desire
* This is inline with how the Android native code handles this URL value.